### PR TITLE
More uzlib Error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Usage
     //#define DEST_FS_USES_SD_MMC
     #define DEST_FS_USES_LITTLEFS
     #include <ESP32-targz.h>
-    // filesystem object will be available as "tarGzFs"
+    // filesystem object will be available as "tarGzFS"
 ```
 
 
@@ -59,7 +59,7 @@ Extract content from `.gz` file
 ```C
 
     // mount spiffs (or any other filesystem)
-    tarGzFs.begin();
+    tarGzFS.begin();
 
     GzUnpacker *GZUnpacker = new GzUnpacker();
 
@@ -74,7 +74,7 @@ Extract content from `.gz` file
     }
 
     // expand another file
-    if( ! gzExpander(tarGzFs, "/blah.gz", tarGzFs, "/blah.jpg") ) {
+    if( ! gzExpander(tarGzFS, "/blah.gz", tarGzFS, "/blah.jpg") ) {
       Serial.printf("operation failed with return code #%d", GZUnpacker->tarGzGetError() );
     }
 
@@ -88,7 +88,7 @@ Expand contents from `.tar` file to `/tmp` folder
 ```C
 
     // mount spiffs (or any other filesystem)
-    tarGzFs.begin();
+    tarGzFS.begin();
 
     TarUnpacker *TARUnpacker = new TarUnpacker();
 
@@ -114,7 +114,7 @@ Expand contents from `.tar.gz`  to `/tmp` folder
 ```C
 
     // mount spiffs (or any other filesystem)
-    tarGzFs.begin();
+    tarGzFS.begin();
 
     TarGzUnpacker *TARGZUnpacker = new TarGzUnpacker();
 
@@ -147,7 +147,7 @@ Flash the ESP with contents from `.gz` file
 ```C
 
     // mount spiffs (or any other filesystem)
-    tarGzFs.begin();
+    tarGzFS.begin();
 
     GzUnpacker *GZUnpacker = new GzUnpacker();
 

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=ESP32-targz
-version=1.0.2-beta
+version=1.0.3-beta
 author=tobozo <tobozo@noreply.github.com>
 maintainer=tobozo <tobozo@noreply.github.com>
 sentence=A library to unpack/uncompress tar, gz, and tar.gz files on ESP32 and ESP8266
@@ -7,5 +7,3 @@ paragraph=ESP32-targz is a wrapper for TinyUntar and uzLib to use with fs::FS. I
 category=Data Processing
 url=https://github.com/tobozo/ESP32-targz/
 architectures=esp32,esp8266
-
-

--- a/src/ESP32-targz-lib.cpp
+++ b/src/ESP32-targz-lib.cpp
@@ -1083,6 +1083,7 @@ int GzUnpacker::gzUncompress( bool isupdate, bool stream_to_tar, bool use_dict, 
   uzLibDecompressor.readSourceByte = gzReadSourceByte;
   uzLibDecompressor.destSize       = 1;
   uzLibDecompressor.log            = targzPrintLoggerCallback;
+  uzLibDecompressor.readSourceErrors = 0;
 
   res = GZ::uzlib_gzip_parse_header(&uzLibDecompressor);
   if (res != TINF_OK) {
@@ -1152,6 +1153,11 @@ int GzUnpacker::gzUncompress( bool isupdate, bool stream_to_tar, bool use_dict, 
     } while ( res == TINF_OK );
 
     if (res != TINF_DONE) {
+      if( uzLibDecompressor.readSourceErrors > 0 ) {
+        free( output_buffer );
+        gzExpanderCleanup();
+        return ESP32_TARGZ_STREAM_ERROR;
+      }
       log_w("[GZ WARNING] uzlib_uncompress_chksum return code=%d, premature end at position %d while %d bytes left", res, output_position, (int)uzlib_bytesleft);
     }
 

--- a/src/uzlib/tinfzlib.c
+++ b/src/uzlib/tinfzlib.c
@@ -44,6 +44,8 @@ int uzlib_zlib_parse_header(TINF_DATA *d)
    cmf = uzlib_get_byte(d);
    flg = uzlib_get_byte(d);
 
+   //if( d->readSourceErrors > 0 ) return TINF_DATA_ERROR;
+
    /* -- check format -- */
 
    /* check checksum */

--- a/src/uzlib/uzlib.h
+++ b/src/uzlib/uzlib.h
@@ -71,6 +71,8 @@ typedef struct TINF_DATA  {
        source_limit fields, thus allowing for buffered operation. */
     int (*source_read_cb)(struct TINF_DATA *uncomp);
     unsigned int (*readSourceByte)(struct TINF_DATA *data, unsigned char *out);
+    //unsigned int readSourceErrors = 0;
+    unsigned int readSourceErrors;
 
     void (*log)( const char* format, ... );
 
@@ -97,11 +99,8 @@ typedef struct TINF_DATA  {
        reading from the output stream, rather than assuming
        'dest' contains the entire output stream in memory
     */
-   unsigned int (*readDestByte)(int offset, unsigned char *out);
-   unsigned int (*writeDestWord)(unsigned long data);
-
-
-
+    unsigned int (*readDestByte)(int offset, unsigned char *out);
+    unsigned int (*writeDestWord)(unsigned long data);
 
     /* Accumulating checksum */
     unsigned int checksum;


### PR DESCRIPTION
This patch addresses issue #27 where uzlib goes into an infinite loop when the incoming data stream is interrupted.
