### PR TITLE
1.1.5

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,31 @@
+name: Lint
+
+on:
+  push:
+    paths:
+    - '**.ino'
+    - '**.ini'
+    - '**.cpp'
+    - '**.hpp'
+    - '**.h'
+    - '**.c'
+    - '**lint.yml'
+
+  pull_request:
+    branches:
+      - main
+
+  workflow_dispatch:
+
+jobs:
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: arduino/arduino-lint-action@v1
+        with:
+          project-type: library
+          library-manager: false
+          recursive: true
+

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ## An ESP32/ESP8266 Arduino library to provide decompression support for .tar, .gz and .tar.gz files
 
 [![arduino-library-badge](https://www.ardu-badge.com/badge/ESP32-targz.svg?)](https://www.ardu-badge.com/ESP32-targz)
+[![PlatformIO Registry](https://badges.registry.platformio.org/packages/tobozo/library/ESP32-targz.svg)](https://registry.platformio.org/packages/libraries/tobozo/ESP32-targz)
 
 <p align="center">
 <img src="ESP32-targz.png" alt="ES32-targz logo" width="512" />
@@ -180,7 +181,7 @@ Flash the ESP with contents from `.gz` file
     GZUnpacker->setGzProgressCallback( BaseUnpacker::defaultProgressCallback ); // targzNullProgressCallback or defaultProgressCallback
     GZUnpacker->setLoggerCallback( BaseUnpacker::targzPrintLoggerCallback  );    // gz log verbosity
 
-    if( ! GZUnpacker->gzUpdater(tarGzFS, firmwareFile, /*don't restart after update*/false ) ) {
+    if( ! GZUnpacker->gzUpdater(tarGzFS, firmwareFile, U_FLASH,/*don't restart after update*/false ) ) {
       Serial.printf("gzUpdater failed with return code #%d\n", GZUnpacker->tarGzGetError() );
     }
 

--- a/library.properties
+++ b/library.properties
@@ -7,3 +7,4 @@ paragraph=ESP32-targz is a wrapper for TinyUntar and uzLib to use with fs::FS. I
 category=Data Processing
 url=https://github.com/tobozo/ESP32-targz/
 architectures=esp32,esp8266
+includes=ESP32-targz.h

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=ESP32-targz
-version=1.1.4
+version=1.1.5
 author=tobozo <tobozo@noreply.github.com>
 maintainer=tobozo <tobozo@noreply.github.com>
 sentence=A library to unpack/uncompress tar, gz, and tar.gz files on ESP32 and ESP8266

--- a/src/ESP32-targz-lib.cpp
+++ b/src/ESP32-targz-lib.cpp
@@ -587,8 +587,10 @@ int TarUnpacker::tarHeaderCallBack( TAR::header_translated_t *header,  CC_UNUSED
       char file_path[256] = {0};
       // check that TAR path does not start with "./" and truncate if necessary
       if( header->filename[0] == '.' && header->filename[1] == '/' ) {
-        snprintf( file_path, 101, "%s", header->filename ); // TAR paths are limited to 100 chars
-        snprintf( header->filename, 101, "%s", &file_path[2] );
+        int truncate_res = snprintf( file_path, 101, "%s", header->filename ); // TAR paths are limited to 100 chars
+        if( truncate_res >=0 ) {
+          snprintf( header->filename, 101, "%s", &file_path[2] );
+        }
       }
       memset( file_path, 0, 256 );
       if( strcmp( tarDestFolder, FOLDER_SEPARATOR ) != 0 ) {

--- a/src/ESP32-targz-lib.cpp
+++ b/src/ESP32-targz-lib.cpp
@@ -44,7 +44,7 @@
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #endif
 
-#include "ESP32-targz-lib.h"
+#include "ESP32-targz-lib.hpp"
 
 struct TarGzIO
 {
@@ -587,10 +587,11 @@ int TarUnpacker::tarHeaderCallBack( TAR::header_translated_t *header,  CC_UNUSED
       char file_path[256] = {0};
       // check that TAR path does not start with "./" and truncate if necessary
       if( header->filename[0] == '.' && header->filename[1] == '/' ) {
-        int truncate_res = snprintf( file_path, 101, "%s", header->filename ); // TAR paths are limited to 100 chars
-        if( truncate_res >=0 ) {
-          snprintf( header->filename, 101, "%s", &file_path[2] );
-        }
+        #pragma GCC diagnostic push
+        #pragma GCC diagnostic ignored "-Wformat-truncation"
+        snprintf( file_path, 101, "%s", header->filename ); // TAR paths are limited to 100 chars
+        snprintf( header->filename, 101, "%s", &file_path[2] );
+        #pragma GCC diagnostic pop
       }
       memset( file_path, 0, 256 );
       if( strcmp( tarDestFolder, FOLDER_SEPARATOR ) != 0 ) {
@@ -2134,6 +2135,102 @@ bool TarGzUnpacker::tarGzStreamExpander( Stream *stream, fs::FS &destFS, const c
   return true;
 }
 
+
+
+
+#if defined ESP32
+
+
+/**    GzUpdateClass Class implementation    **/
+
+bool GzUpdateClass::begingz(size_t size, int command, int ledPin, uint8_t ledOn, const char *label)
+{
+  if( !gzProgressCallback ) {
+    log_d("Setting progress cb");
+    gzUnpacker.setGzProgressCallback( gzUnpacker.defaultProgressCallback );
+  }
+  if( !tgzLogger ) {
+    log_d("Setting logger cb");
+    gzUnpacker.setLoggerCallback( gzUnpacker.targzPrintLoggerCallback );
+  }
+  if( gzWriteCallback == nullptr ) {
+    log_d("Setting write cb");
+    gzUnpacker.setStreamWriter( gzUpdateWriteCallback );
+    //gzUnpacker.setStreamWriter( Update.write );
+  }
+
+  mode_gz = true;
+
+  bool ret = begin(size, command, ledPin, ledOn, label);
+
+  return ret;
+}
+
+
+
+bool GzUpdateClass::gzUpdateWriteCallback( unsigned char* buff, size_t buffsize )
+{
+  if( GzUpdateClass::getInstance().write( buff, buffsize ) ) {
+    log_v("Wrote %d bytes", buffsize );
+    return true;
+  }
+  log_e("Failed to write %d bytes", buffsize );
+  return false;
+}
+
+
+void GzUpdateClass::abortgz()
+{
+  abort();
+  gzUnpacker.gzExpanderCleanup();
+  mode_gz = false;
+}
+
+
+bool GzUpdateClass::endgz(bool evenIfRemaining)
+{
+  gzUnpacker.gzExpanderCleanup();
+  mode_gz = false;
+  return end(evenIfRemaining);
+}
+
+
+size_t GzUpdateClass::writeGzStream(Stream &data, size_t len)
+{
+  if (!mode_gz) {
+    log_d("Not in gz mode");
+    return writeStream(data);
+  }
+
+  size_t size = data.available();
+  if( ! size ) {
+    log_e("Bad stream, aborting");
+    //gzUnpacker.setError( ESP32_TARGZ_STREAM_ERROR );
+    return 0;
+  }
+
+  log_d("In gz mode");
+
+  tarGzIO.gz = &data;
+  // process with unzipping
+  bool show_progress = false;
+  bool use_dict      = true;
+  bool isupdate      = true;
+  bool stream_to_tar = false;
+  int ret = gzUnpacker.gzUncompress( isupdate, stream_to_tar, use_dict, show_progress );
+  // unzipping ended
+  if( ret!=0 ) {
+    log_e("gzHTTPUpdater returned error code %d", ret);
+    //gzUnpacker.setError( (tarGzErrorCode)ret );
+    return 0;
+  }
+
+  log_d("unpack complete (%d bytes)", tarGzIO.gz_size );
+
+  return len;
+}
+
+#endif
 
 
 

--- a/src/ESP32-targz.h
+++ b/src/ESP32-targz.h
@@ -108,7 +108,7 @@
 
 // required filesystem helpers are declared outside the main library
 // because ESP32/ESP8266 <FS.h> use different abstraction flavours :)
-size_t targzFreeBytesFn() {
+__attribute__((unused)) static size_t targzFreeBytesFn() {
   #if defined DEST_FS_USES_SPIFFS || defined DEST_FS_USES_SD || defined DEST_FS_USES_SD_MMC || defined DEST_FS_USES_LITTLEFS || defined DEST_FS_USES_PSRAMFS
     #if defined ESP32
       return tarGzFS.totalBytes() - tarGzFS.usedBytes();
@@ -129,7 +129,7 @@ size_t targzFreeBytesFn() {
   #endif
 }
 
-size_t targzTotalBytesFn() {
+__attribute__((unused)) static size_t targzTotalBytesFn() {
   #if defined DEST_FS_USES_SPIFFS || defined DEST_FS_USES_SD || defined DEST_FS_USES_SD_MMC || defined DEST_FS_USES_LITTLEFS || defined DEST_FS_USES_FFAT || defined DEST_FS_USES_PSRAMFS
     #if defined ESP32
       return tarGzFS.totalBytes();
@@ -149,6 +149,6 @@ size_t targzTotalBytesFn() {
 }
 
 
-#include "ESP32-targz-lib.h"
+#include "ESP32-targz-lib.hpp"
 
 #endif

--- a/src/TinyUntar/untar.c
+++ b/src/TinyUntar/untar.c
@@ -1,6 +1,6 @@
 #include "untar.h"
 
-char *empty_string = "";
+const char *empty_string = "";
 entry_callbacks_t *read_tar_callbacks = NULL;
 unsigned char *read_buffer = NULL;
 header_t header;
@@ -68,7 +68,7 @@ char *trim(char *raw, int length) {
     }
   }
   if(is_empty == 1)
-    return empty_string;
+    return (char*)empty_string;
   // Determine right padding.
   while((raw[j] == 0 || raw[j] == ' ')) {
     j--;


### PR DESCRIPTION
- Fixed compilation warnings
- Renamed `src/ESP32-targz-lib.h` -> `src/ESP32-targz-lib.hpp`
- Added GzUpdateClass for ESP32 (still experimental)